### PR TITLE
Fix regex rule creation

### DIFF
--- a/src/rules/ValidationEngine.test.ts
+++ b/src/rules/ValidationEngine.test.ts
@@ -87,4 +87,17 @@ describe('ValidationEngine', () => {
         expect(result.isValid).toBe(false);
         expect(result.errors).toEqual(['This field is required.']);
     });
+
+    it('should create regex rule from configuration', () => {
+        const rules = [
+            { rule: 'regex', params: { regex: '^[a-z]+$' }, message: 'Only letters allowed.' }
+        ];
+
+        const validationEngine = new ValidationEngine(rules);
+
+        const result = validationEngine.validateValue('abc123');
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(['Only letters allowed.']);
+    });
 });

--- a/src/rules/ValidationEngine.ts
+++ b/src/rules/ValidationEngine.ts
@@ -4,6 +4,7 @@ import MinValidationRule from "./MinValidationRule.ts";
 import MaxValidationRule from "./MaxValidationRule.ts";
 import EmailValidationRule from "./EmailValidationRule.ts";
 import DomainValidationRule from "./DomainValidationRule.ts";
+import RegexValidationRule from "./RegexValidationRule.ts";
 
 export default class ValidationEngine {
     private rules: IValidationRule[] = [];
@@ -53,6 +54,9 @@ export default class ValidationEngine {
                 break;
             case 'domain':
                 validationRule = new DomainValidationRule();
+                break;
+            case 'regex':
+                validationRule = new RegexValidationRule(params.regex || '');
                 break;
             default:
                 console.warn(`Unknown validation rule: ${type}`);


### PR DESCRIPTION
## Summary
- allow ValidationEngine to create RegexValidationRule
- test regex rule configuration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff1ec1fb88326be60acfa69240d41