### PR TITLE
Fix export declaration

### DIFF
--- a/src/rules/DomainValidationRule.ts
+++ b/src/rules/DomainValidationRule.ts
@@ -1,6 +1,6 @@
 import IValidationRule from "./IValidationRule.ts";
 
-export  default class DomainValidationRule implements IValidationRule {
+export default class DomainValidationRule implements IValidationRule {
     private errorMessage: string = "This field must be a valid domain.";
 
     isValid(param: string): [boolean, string] {


### PR DESCRIPTION
## Summary
- trim redundant space in `DomainValidationRule` export declaration

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff495d2dc832690207bba6c75a18a