### PR TITLE
Add empty string validation test

### DIFF
--- a/src/rules/RegexValidationRule.test.ts
+++ b/src/rules/RegexValidationRule.test.ts
@@ -9,6 +9,13 @@ describe('MinValidationRule', () => {
         expect(errorMessage).toBe('');
     });
 
+    it('should return true and empty message for an empty string', () => {
+        const rule = new RegexValidationRule("^[a-zA-Z]+$");
+        const [isValid, errorMessage] = rule.isValid('');
+        expect(isValid).toBe(true);
+        expect(errorMessage).toBe('');
+    });
+
     it('should return false for string that doesn\'t match the given regex', () => {
         const rule = new RegexValidationRule("^[a-zA-Z]$");
         const [isValid, errorMessage] = rule.isValid('test123');


### PR DESCRIPTION
## Summary
- test `RegexValidationRule` with an empty string value

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff4b9d8f083269da681e79d2bd711