### PR TITLE
Implement additional validation rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,17 @@ export { default as RequiredValidationRule } from "./rules/RequiredValidationRul
 export { default as ValidationEngine } from "./rules/ValidationEngine.ts";
 export { default as IValidationRule } from "./rules/IValidationRule.ts";
 export { default as RegexValidationRule } from "./rules/RegexValidationRule.ts";
+export { default as BankAccountValidationRule } from "./rules/BankAccountValidationRule.ts";
+export { default as CreditCardValidationRule } from "./rules/CreditCardValidationRule.ts";
+export { default as ZipCodeValidationRule } from "./rules/ZipCodeValidationRule.ts";
+export { default as PhoneNumberValidationRule } from "./rules/PhoneNumberValidationRule.ts";
+export { default as DateValidationRule } from "./rules/DateValidationRule.ts";
+export { default as UrlValidationRule } from "./rules/UrlValidationRule.ts";
+export { default as UsernameValidationRule } from "./rules/UsernameValidationRule.ts";
+export { default as PasswordStrengthValidationRule } from "./rules/PasswordStrengthValidationRule.ts";
+export { default as IpAddressValidationRule } from "./rules/IpAddressValidationRule.ts";
+export { default as CurrencyValidationRule } from "./rules/CurrencyValidationRule.ts";
+export { default as SocialSecurityValidationRule } from "./rules/SocialSecurityValidationRule.ts";
 
 export { default as FormValidationEngine } from "./form/FormValidationEngine.ts";
 export { default as MatchFieldValidationRule } from "./rules/MatchFieldValidationRule.ts";

--- a/src/rules/BankAccountValidationRule.test.ts
+++ b/src/rules/BankAccountValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import BankAccountValidationRule from './BankAccountValidationRule'
+
+describe('BankAccountValidationRule', () => {
+  it('validates numeric account numbers', () => {
+    const rule = new BankAccountValidationRule()
+    expect(rule.isValid('12345678')).toEqual([true, ''])
+  })
+
+  it('rejects invalid account numbers', () => {
+    const rule = new BankAccountValidationRule()
+    expect(rule.isValid('abc')).toEqual([false, 'This field must be a valid bank account number.'])
+  })
+})

--- a/src/rules/BankAccountValidationRule.ts
+++ b/src/rules/BankAccountValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class BankAccountValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid bank account number.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^\d{8,20}$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'bankaccount'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/CreditCardValidationRule.test.ts
+++ b/src/rules/CreditCardValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import CreditCardValidationRule from './CreditCardValidationRule'
+
+describe('CreditCardValidationRule', () => {
+  it('accepts valid card number', () => {
+    const rule = new CreditCardValidationRule()
+    expect(rule.isValid('4111 1111 1111 1111')).toEqual([true, ''])
+  })
+
+  it('rejects invalid card number', () => {
+    const rule = new CreditCardValidationRule()
+    expect(rule.isValid('1234')).toEqual([false, 'This field must be a valid credit card number.'])
+  })
+})

--- a/src/rules/CreditCardValidationRule.ts
+++ b/src/rules/CreditCardValidationRule.ts
@@ -1,0 +1,37 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class CreditCardValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid credit card number.'
+
+  private luhnCheck(num: string): boolean {
+    let sum = 0
+    let shouldDouble = false
+    for (let i = num.length - 1; i >= 0; i--) {
+      let digit = parseInt(num.charAt(i), 10)
+      if (shouldDouble) {
+        digit *= 2
+        if (digit > 9) digit -= 9
+      }
+      sum += digit
+      shouldDouble = !shouldDouble
+    }
+    return sum % 10 === 0
+  }
+
+  isValid(param: string): [boolean, string] {
+    const digits = param.replace(/[^0-9]/g, '')
+    const isValid = /^[0-9]{13,19}$/.test(digits) && this.luhnCheck(digits)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'creditcard'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/CurrencyValidationRule.test.ts
+++ b/src/rules/CurrencyValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import CurrencyValidationRule from './CurrencyValidationRule'
+
+describe('CurrencyValidationRule', () => {
+  it('accepts currency format', () => {
+    const rule = new CurrencyValidationRule()
+    expect(rule.isValid('$10.00')).toEqual([true, ''])
+  })
+
+  it('rejects invalid currency', () => {
+    const rule = new CurrencyValidationRule()
+    expect(rule.isValid('ten')).toEqual([false, 'This field must be a valid currency amount.'])
+  })
+})

--- a/src/rules/CurrencyValidationRule.ts
+++ b/src/rules/CurrencyValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class CurrencyValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid currency amount.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^\$?\d+(?:\.\d{2})?$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'currency'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/DateValidationRule.test.ts
+++ b/src/rules/DateValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import DateValidationRule from './DateValidationRule'
+
+describe('DateValidationRule', () => {
+  it('accepts valid date', () => {
+    const rule = new DateValidationRule()
+    expect(rule.isValid('2024-01-01')).toEqual([true, ''])
+  })
+
+  it('rejects invalid date', () => {
+    const rule = new DateValidationRule()
+    expect(rule.isValid('2024-13-01')).toEqual([false, 'This field must be a valid date.'])
+  })
+})

--- a/src/rules/DateValidationRule.ts
+++ b/src/rules/DateValidationRule.ts
@@ -1,0 +1,26 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class DateValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid date.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^\d{4}-\d{2}-\d{2}$/
+    let isValid = false
+    if (pattern.test(param)) {
+      const date = new Date(param)
+      isValid = !isNaN(date.getTime()) && param === date.toISOString().slice(0,10)
+    }
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'date'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/IpAddressValidationRule.test.ts
+++ b/src/rules/IpAddressValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import IpAddressValidationRule from './IpAddressValidationRule'
+
+describe('IpAddressValidationRule', () => {
+  it('accepts valid ipv4', () => {
+    const rule = new IpAddressValidationRule()
+    expect(rule.isValid('192.168.0.1')).toEqual([true, ''])
+  })
+
+  it('rejects invalid ip', () => {
+    const rule = new IpAddressValidationRule()
+    expect(rule.isValid('999.999.999.999')).toEqual([false, 'This field must be a valid IP address.'])
+  })
+})

--- a/src/rules/IpAddressValidationRule.ts
+++ b/src/rules/IpAddressValidationRule.ts
@@ -1,0 +1,23 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class IpAddressValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid IP address.'
+
+  isValid(param: string): [boolean, string] {
+    const ipv4 = /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/
+    const ipv6 = /^[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){7}$/
+    const isValid = ipv4.test(param) || ipv6.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'ip'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/PasswordStrengthValidationRule.test.ts
+++ b/src/rules/PasswordStrengthValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import PasswordStrengthValidationRule from './PasswordStrengthValidationRule'
+
+describe('PasswordStrengthValidationRule', () => {
+  it('accepts strong password', () => {
+    const rule = new PasswordStrengthValidationRule()
+    expect(rule.isValid('Aa1!aaaa')).toEqual([true, ''])
+  })
+
+  it('rejects weak password', () => {
+    const rule = new PasswordStrengthValidationRule()
+    expect(rule.isValid('weak')).toEqual([false, 'Password is too weak.'])
+  })
+})

--- a/src/rules/PasswordStrengthValidationRule.ts
+++ b/src/rules/PasswordStrengthValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class PasswordStrengthValidationRule implements IValidationRule {
+  private errorMessage = 'Password is too weak.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'password'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/PhoneNumberValidationRule.test.ts
+++ b/src/rules/PhoneNumberValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import PhoneNumberValidationRule from './PhoneNumberValidationRule'
+
+describe('PhoneNumberValidationRule', () => {
+  it('accepts valid phone', () => {
+    const rule = new PhoneNumberValidationRule()
+    expect(rule.isValid('+1234567890')).toEqual([true, ''])
+  })
+
+  it('rejects invalid phone', () => {
+    const rule = new PhoneNumberValidationRule()
+    expect(rule.isValid('abc')).toEqual([false, 'This field must be a valid phone number.'])
+  })
+})

--- a/src/rules/PhoneNumberValidationRule.ts
+++ b/src/rules/PhoneNumberValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class PhoneNumberValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid phone number.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^\+?[1-9]\d{1,14}$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'phone'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/SocialSecurityValidationRule.test.ts
+++ b/src/rules/SocialSecurityValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import SocialSecurityValidationRule from './SocialSecurityValidationRule'
+
+describe('SocialSecurityValidationRule', () => {
+  it('accepts valid ssn', () => {
+    const rule = new SocialSecurityValidationRule()
+    expect(rule.isValid('123-45-6789')).toEqual([true, ''])
+  })
+
+  it('rejects invalid ssn', () => {
+    const rule = new SocialSecurityValidationRule()
+    expect(rule.isValid('123')).toEqual([false, 'This field must be a valid SSN.'])
+  })
+})

--- a/src/rules/SocialSecurityValidationRule.ts
+++ b/src/rules/SocialSecurityValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class SocialSecurityValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid SSN.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^\d{3}-?\d{2}-?\d{4}$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'ssn'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/UrlValidationRule.test.ts
+++ b/src/rules/UrlValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import UrlValidationRule from './UrlValidationRule'
+
+describe('UrlValidationRule', () => {
+  it('accepts valid url', () => {
+    const rule = new UrlValidationRule()
+    expect(rule.isValid('https://example.com')).toEqual([true, ''])
+  })
+
+  it('rejects invalid url', () => {
+    const rule = new UrlValidationRule()
+    expect(rule.isValid('not a url')).toEqual([false, 'This field must be a valid URL.'])
+  })
+})

--- a/src/rules/UrlValidationRule.ts
+++ b/src/rules/UrlValidationRule.ts
@@ -1,0 +1,26 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class UrlValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid URL.'
+
+  isValid(param: string): [boolean, string] {
+    try {
+      const url = new URL(param)
+      const isValid = url.protocol === 'http:' || url.protocol === 'https:'
+      return [isValid, isValid ? '' : this.errorMessage]
+    } catch {
+      return [false, this.errorMessage]
+    }
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'url'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/UsernameValidationRule.test.ts
+++ b/src/rules/UsernameValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import UsernameValidationRule from './UsernameValidationRule'
+
+describe('UsernameValidationRule', () => {
+  it('accepts valid username', () => {
+    const rule = new UsernameValidationRule()
+    expect(rule.isValid('user_1')).toEqual([true, ''])
+  })
+
+  it('rejects invalid username', () => {
+    const rule = new UsernameValidationRule()
+    expect(rule.isValid('no')).toEqual([false, 'This field must be a valid username.'])
+  })
+})

--- a/src/rules/UsernameValidationRule.ts
+++ b/src/rules/UsernameValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class UsernameValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid username.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^[A-Za-z0-9_]{3,20}$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'username'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/ValidationEngine.ts
+++ b/src/rules/ValidationEngine.ts
@@ -5,6 +5,17 @@ import MaxValidationRule from "./MaxValidationRule.ts";
 import EmailValidationRule from "./EmailValidationRule.ts";
 import DomainValidationRule from "./DomainValidationRule.ts";
 import RegexValidationRule from "./RegexValidationRule.ts";
+import BankAccountValidationRule from "./BankAccountValidationRule.ts";
+import CreditCardValidationRule from "./CreditCardValidationRule.ts";
+import ZipCodeValidationRule from "./ZipCodeValidationRule.ts";
+import PhoneNumberValidationRule from "./PhoneNumberValidationRule.ts";
+import DateValidationRule from "./DateValidationRule.ts";
+import UrlValidationRule from "./UrlValidationRule.ts";
+import UsernameValidationRule from "./UsernameValidationRule.ts";
+import PasswordStrengthValidationRule from "./PasswordStrengthValidationRule.ts";
+import IpAddressValidationRule from "./IpAddressValidationRule.ts";
+import CurrencyValidationRule from "./CurrencyValidationRule.ts";
+import SocialSecurityValidationRule from "./SocialSecurityValidationRule.ts";
 
 export default class ValidationEngine {
     private rules: IValidationRule[] = [];
@@ -61,6 +72,39 @@ export default class ValidationEngine {
                 break;
             case 'regex':
                 validationRule = new RegexValidationRule(params.regex || '');
+                break;
+            case 'bankaccount':
+                validationRule = new BankAccountValidationRule();
+                break;
+            case 'creditcard':
+                validationRule = new CreditCardValidationRule();
+                break;
+            case 'zipcode':
+                validationRule = new ZipCodeValidationRule();
+                break;
+            case 'phone':
+                validationRule = new PhoneNumberValidationRule();
+                break;
+            case 'date':
+                validationRule = new DateValidationRule();
+                break;
+            case 'url':
+                validationRule = new UrlValidationRule();
+                break;
+            case 'username':
+                validationRule = new UsernameValidationRule();
+                break;
+            case 'password':
+                validationRule = new PasswordStrengthValidationRule();
+                break;
+            case 'ip':
+                validationRule = new IpAddressValidationRule();
+                break;
+            case 'currency':
+                validationRule = new CurrencyValidationRule();
+                break;
+            case 'ssn':
+                validationRule = new SocialSecurityValidationRule();
                 break;
             default:
                 console.warn(`Unknown validation rule: ${type}`);

--- a/src/rules/ZipCodeValidationRule.test.ts
+++ b/src/rules/ZipCodeValidationRule.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import ZipCodeValidationRule from './ZipCodeValidationRule'
+
+describe('ZipCodeValidationRule', () => {
+  it('accepts valid zip', () => {
+    const rule = new ZipCodeValidationRule()
+    expect(rule.isValid('12345')).toEqual([true, ''])
+  })
+
+  it('rejects invalid zip', () => {
+    const rule = new ZipCodeValidationRule()
+    expect(rule.isValid('12-34')).toEqual([false, 'This field must be a valid ZIP code.'])
+  })
+})

--- a/src/rules/ZipCodeValidationRule.ts
+++ b/src/rules/ZipCodeValidationRule.ts
@@ -1,0 +1,22 @@
+import IValidationRule from './IValidationRule.ts'
+
+export default class ZipCodeValidationRule implements IValidationRule {
+  private errorMessage = 'This field must be a valid ZIP code.'
+
+  isValid(param: string): [boolean, string] {
+    const pattern = /^\d{5}(?:-\d{4})?$/
+    const isValid = pattern.test(param)
+    return [isValid, isValid ? '' : this.errorMessage]
+  }
+
+  isMatch(type: string): boolean {
+    return type.toLowerCase() === 'zipcode'
+  }
+
+  // @ts-ignore
+  setParams(params: any): void {}
+
+  setErrorMessage(message: string): void {
+    this.errorMessage = message
+  }
+}

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -5,6 +5,17 @@ import EmailValidationRule from "./EmailValidationRule.ts";
 import DomainValidationRule from "./DomainValidationRule.ts";
 import IValidationRule  from "./IValidationRule.ts";
 import RegexValidationRule from "@/rules/RegexValidationRule.ts";
+import BankAccountValidationRule from "./BankAccountValidationRule.ts";
+import CreditCardValidationRule from "./CreditCardValidationRule.ts";
+import ZipCodeValidationRule from "./ZipCodeValidationRule.ts";
+import PhoneNumberValidationRule from "./PhoneNumberValidationRule.ts";
+import DateValidationRule from "./DateValidationRule.ts";
+import UrlValidationRule from "./UrlValidationRule.ts";
+import UsernameValidationRule from "./UsernameValidationRule.ts";
+import PasswordStrengthValidationRule from "./PasswordStrengthValidationRule.ts";
+import IpAddressValidationRule from "./IpAddressValidationRule.ts";
+import CurrencyValidationRule from "./CurrencyValidationRule.ts";
+import SocialSecurityValidationRule from "./SocialSecurityValidationRule.ts";
 
 export default {
     RequiredValidationRule,
@@ -14,4 +25,15 @@ export default {
     DomainValidationRule,
     IValidationRule,
     RegexValidationRule,
+    BankAccountValidationRule,
+    CreditCardValidationRule,
+    ZipCodeValidationRule,
+    PhoneNumberValidationRule,
+    DateValidationRule,
+    UrlValidationRule,
+    UsernameValidationRule,
+    PasswordStrengthValidationRule,
+    IpAddressValidationRule,
+    CurrencyValidationRule,
+    SocialSecurityValidationRule,
 }


### PR DESCRIPTION
## Summary
- add extensive validation rules for bank account numbers, credit card numbers, zip codes, phone numbers, dates, urls and more
- expose the new rules from the main index
- register the new rules in the validation engine
- test all validation logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6844b60466ac8326a9deee5e93fdd7bd