### PR TITLE
Fix ValidationEngine constructor typing

### DIFF
--- a/src/rules/ValidationEngine.ts
+++ b/src/rules/ValidationEngine.ts
@@ -9,7 +9,7 @@ import RegexValidationRule from "./RegexValidationRule.ts";
 export default class ValidationEngine {
     private rules: IValidationRule[] = [];
 
-    constructor(initialRules: Array<string | { rule: string, params: any, message?: string }> = []) {
+    constructor(initialRules: Array<string | { rule: string, params: any, message?: string } | IValidationRule> = []) {
         initialRules.forEach(rule => this.addRule(rule));
     }
 


### PR DESCRIPTION
## Summary
- allow custom IValidationRule objects when creating ValidationEngine

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68490a7713a88326b24bb551fec6fb7a